### PR TITLE
feat(budget-cycles): Implement alarm cancellation for cycle completion

### DIFF
--- a/app/src/main/java/dev/ridill/oar/budgetCycles/data/repository/BudgetCycleRepositoryImpl.kt
+++ b/app/src/main/java/dev/ridill/oar/budgetCycles/data/repository/BudgetCycleRepositoryImpl.kt
@@ -210,8 +210,10 @@ class BudgetCycleRepositoryImpl(
         cycleDao.getLastCycle()?.toEntry()
     }
 
-    override fun scheduleCycleCompletion(cycle: BudgetCycleEntry): Result<Unit, BudgetCycleError> =
-        manager.scheduleCycleCompletion(
+    override fun scheduleCycleCompletion(
+        cycle: BudgetCycleEntry
+    ): Result<Unit, BudgetCycleError> = manager
+        .scheduleCycleCompletion(
             cycleId = cycle.id,
             endDate = cycle.endDate
                 .plusDays(1)
@@ -268,6 +270,7 @@ class BudgetCycleRepositoryImpl(
             val activeCycle = cycleDao.getActiveCycle()
                 ?: throw CycleNotFoundThrowable(cycleId)
             logD(TAG) { "entry = $entry created with ID = $cycleId" }
+            existingCycle?.id?.let { manager.cancelCycleCompletion(it) }
             scheduleCycleCompletion(activeCycle.toEntry(true))
         } catch (t: CycleEntryCreationFailedThrowable) {
             logE(t, TAG) { "createNewCycleAndScheduleCompletion" }
@@ -475,7 +478,7 @@ class BudgetCycleRepositoryImpl(
                 configValue = id.toString()
             )
         )
-        logI(TAG) {"set Id = $id as active cycle"  }
+        logI(TAG) { "set Id = $id as active cycle" }
     }
 
     override suspend fun getCyclesSelectorsPagingData(

--- a/app/src/main/java/dev/ridill/oar/budgetCycles/domain/cycleManager/CycleAlarmManager.kt
+++ b/app/src/main/java/dev/ridill/oar/budgetCycles/domain/cycleManager/CycleAlarmManager.kt
@@ -23,23 +23,17 @@ class CycleAlarmManager(
     override fun canScheduleExactAlarms(): Boolean = !BuildUtil.isApiLevelAtLeast31
             || alarmManager.canScheduleExactAlarms()
 
+    override fun cancelCycleCompletion(cycleId: Long) {
+        val pendingIntent = buildPendingIntent(cycleId)
+        alarmManager.cancel(pendingIntent)
+    }
+
     override fun scheduleCycleCompletion(
         cycleId: Long,
         endDate: LocalDateTime
     ): Result<Unit, BudgetCycleError> = try {
         val endTimeMillis = DateUtil.toMillis(endDate)
-
-        val intent = Intent(context, CycleCompletionReceiver::class.java).apply {
-            this.action = CycleManager.action(context)
-            putExtra(CycleManager.EXTRA_CYCLE_ID, cycleId)
-        }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            cycleId.hashCode(),
-            intent,
-            UtilConstants.pendingIntentFlags
-        )
-
+        val pendingIntent = buildPendingIntent(cycleId)
         alarmManager.setWindow(
             AlarmManager.RTC,
             endTimeMillis,
@@ -47,14 +41,26 @@ class CycleAlarmManager(
             pendingIntent
         )
 
-        logD("CycleManager") { "Scheduled cycle ID = $cycleId to complete at $endDate" }
-
+        logD(CycleManager::class.simpleName) { "Scheduled cycle ID = $cycleId to complete at $endDate" }
         Result.Success(Unit)
     } catch (t: Throwable) {
-        logE(t, "CycleManager")
+        logE(t, CycleManager::class.simpleName)
         Result.Error(
             BudgetCycleError.CYCLE_SCHEDULE_FAILED,
             UiText.StringResource(R.string.error_failed_to_schedule_cycle, true)
+        )
+    }
+
+    private fun buildPendingIntent(cycleId: Long): PendingIntent {
+        val intent = Intent(context, CycleCompletionReceiver::class.java).apply {
+            this.action = CycleManager.action(context)
+            putExtra(CycleManager.EXTRA_CYCLE_ID, cycleId)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            cycleId.hashCode(),
+            intent,
+            UtilConstants.pendingIntentFlags
         )
     }
 }

--- a/app/src/main/java/dev/ridill/oar/budgetCycles/domain/cycleManager/CycleManager.kt
+++ b/app/src/main/java/dev/ridill/oar/budgetCycles/domain/cycleManager/CycleManager.kt
@@ -16,6 +16,8 @@ interface CycleManager {
 
     fun canScheduleExactAlarms(): Boolean
 
+    fun cancelCycleCompletion(cycleId: Long)
+
     fun scheduleCycleCompletion(
         cycleId: Long,
         endDate: LocalDateTime


### PR DESCRIPTION
- Add `cancelCycleCompletion` to the `CycleManager` interface and implement it in `CycleAlarmManager`.
- Refactor `CycleAlarmManager` to use a private `buildPendingIntent` helper for both scheduling and cancelling alarms.
- Update `BudgetCycleRepositoryImpl` to cancel the alarm for an existing cycle before scheduling a completion alarm for a new cycle.
- Improve logging consistency in `CycleAlarmManager` using class simple names.