### PR TITLE
feat(settings): Refine App Lock service logic and lifecycle management

### DIFF
--- a/app/src/main/java/dev/ridill/oar/application/OarActivity.kt
+++ b/app/src/main/java/dev/ridill/oar/application/OarActivity.kt
@@ -170,7 +170,7 @@ class OarActivity : AppCompatActivity() {
     }
 
     override fun onStop() {
-        viewModel.startAppAutoLockTimer()
+        viewModel.startAppAutoLockTimerIfApplicable()
         super.onStop()
     }
 

--- a/app/src/main/java/dev/ridill/oar/application/OarViewModel.kt
+++ b/app/src/main/java/dev/ridill/oar/application/OarViewModel.kt
@@ -99,9 +99,18 @@ class OarViewModel @Inject constructor(
             }
     }
 
-    fun startAppAutoLockTimer() = viewModelScope.launch {
+    fun startAppAutoLockTimerIfApplicable() = viewModelScope.launch {
         val preferences = preferences.first()
-        if (!preferences.appLockEnabled || preferences.isAppLocked) return@launch
+        if (!preferences.appLockEnabled) {
+            // Stop the entire service because app lock not enabled.
+            appLockServiceManager.stopAppUnlockedIndicator()
+            return@launch
+        }
+        if (preferences.isAppLocked) {
+            // Stop the timer because app is locked.
+            appLockServiceManager.stopAppLockTimer()
+            return@launch
+        }
 
         appLockServiceManager.startAppAutoLockTimer()
     }
@@ -109,7 +118,7 @@ class OarViewModel @Inject constructor(
     fun startAppUnlockOrServiceStop() = viewModelScope.launch {
         val preferences = preferences.first()
         if (!preferences.appLockEnabled) {
-            appLockServiceManager.stopAppLockTimer()
+            appLockServiceManager.stopAppUnlockedIndicator()
             return@launch
         }
         if (preferences.isAppLocked) {

--- a/app/src/main/java/dev/ridill/oar/settings/domain/appLock/AppLockService.kt
+++ b/app/src/main/java/dev/ridill/oar/settings/domain/appLock/AppLockService.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.ridill.oar.R
 import dev.ridill.oar.core.data.preferences.PreferencesManager
 import dev.ridill.oar.core.domain.notification.NotificationHelper
+import dev.ridill.oar.core.domain.util.BuildUtil
 import dev.ridill.oar.core.domain.util.logI
 import dev.ridill.oar.di.AppLockFeature
 import kotlinx.coroutines.CoroutineScope
@@ -21,6 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
 class AppLockService : Service() {
@@ -59,10 +61,12 @@ class AppLockService : Service() {
         logI(AppLockService::class.simpleName) { "Starting app lock timer" }
         timerJob?.cancel()
         timerJob = serviceScope.launch {
-            val interval = preferencesManager.preferences.first().appAutoLockInterval
-            delay(interval.duration)
-            logI(AppLockService::class.simpleName) { "Locking app after auto lock timer" }
+            val interval = if (BuildUtil.isDebug) 3.seconds
+            else preferencesManager.preferences.first().appAutoLockInterval.duration
+            logI(AppLockService::class.simpleName) { "Locking app after $interval" }
+            delay(interval)
             preferencesManager.updateAppLocked(true)
+            logI(AppLockService::class.simpleName) { "App locked" }
             stopSelf()
         }
     }

--- a/app/src/main/java/dev/ridill/oar/settings/domain/appLock/AppLockServiceManager.kt
+++ b/app/src/main/java/dev/ridill/oar/settings/domain/appLock/AppLockServiceManager.kt
@@ -12,25 +12,25 @@ class AppLockServiceManager(
     private val context: Context
 ) {
     fun startAppUnlockedIndicator() {
-        startServiceWithAction(AppLockService.Action.INIT_SERVICE)
+        performServiceAction(AppLockService.Action.INIT_SERVICE)
     }
 
     fun stopAppUnlockedIndicator() {
-        startServiceWithAction(AppLockService.Action.STOP_SERVICE)
+        performServiceAction(AppLockService.Action.STOP_SERVICE)
     }
 
     fun startAppAutoLockTimer() {
-        startServiceWithAction(AppLockService.Action.START_AUTO_LOCK_TIMER)
+        performServiceAction(AppLockService.Action.START_AUTO_LOCK_TIMER)
     }
 
     fun stopAppLockTimer() {
-        startServiceWithAction(AppLockService.Action.STOP_AUTO_LOCK_TIMER)
+        performServiceAction(AppLockService.Action.STOP_AUTO_LOCK_TIMER)
     }
 
-    private fun startServiceWithAction(
+    private fun performServiceAction(
         serviceAction: AppLockService.Action
     ) {
-        logI(AppLockService::class.simpleName) { "startServiceWithAction() called with: action = $serviceAction" }
+        logI(AppLockService::class.simpleName) { "performServiceAction() called with: action = $serviceAction" }
         tryOrNull(AppLockServiceManager::class.java.name) {
             val serviceIntent = Intent(context, AppLockService::class.java).apply {
                 action = serviceAction.name


### PR DESCRIPTION
- Reduce auto-lock delay to 3 seconds in debug builds for easier testing.
- Rename `startServiceWithAction` to `performServiceAction` in `AppLockServiceManager` for clarity.
- Update `OarViewModel` logic to explicitly stop the app lock service when the feature is disabled or the app is already locked.
- Ensure `AppLockService` stops itself after the auto-lock timer expires and the app is locked.
- Improve logging throughout the app lock flow to better track timer status and lock events.