### PR TITLE
fix(ui): fix incorrect bottom sheet behaviour

### DIFF
--- a/app/src/main/java/dev/ridill/oar/core/ui/components/BottomSheet.kt
+++ b/app/src/main/java/dev/ridill/oar/core/ui/components/BottomSheet.kt
@@ -63,7 +63,10 @@ import dev.ridill.oar.core.ui.util.UiText
 fun OarModalBottomSheet(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden),
+    sheetState: SheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)
+    ),
     sheetMaxWidth: Dp = BottomSheetDefaults.SheetMaxWidth,
     shape: Shape = BottomSheetDefaults.ExpandedShape,
     containerColor: Color = BottomSheetDefaults.ContainerColor,

--- a/app/src/main/java/dev/ridill/oar/folders/presentation/addEditFolder/AddEditFolderSheet.kt
+++ b/app/src/main/java/dev/ridill/oar/folders/presentation/addEditFolder/AddEditFolderSheet.kt
@@ -25,6 +25,7 @@ import dev.ridill.oar.core.ui.components.OutlinedTextFieldSheet
 import dev.ridill.oar.core.ui.theme.spacing
 import dev.ridill.oar.core.ui.util.UiText
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun AddEditFolderSheet(
@@ -40,7 +41,7 @@ fun AddEditFolderSheet(
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(isEditMode) {
         if (!isEditMode) {
-            delay(500)
+            delay(500.milliseconds)
             focusRequester.requestFocus()
         }
     }

--- a/app/src/main/java/dev/ridill/oar/settings/presentation/backupEncryption/BackupEncryptionScreen.kt
+++ b/app/src/main/java/dev/ridill/oar/settings/presentation/backupEncryption/BackupEncryptionScreen.kt
@@ -17,13 +17,10 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumFlexibleTopAppBar
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -45,6 +42,7 @@ import dev.ridill.oar.core.ui.components.BackArrowButton
 import dev.ridill.oar.core.ui.components.ButtonWithLoadingIndicator
 import dev.ridill.oar.core.ui.components.DisplayMediumText
 import dev.ridill.oar.core.ui.components.DisplaySmallText
+import dev.ridill.oar.core.ui.components.OarModalBottomSheet
 import dev.ridill.oar.core.ui.components.OarScaffold
 import dev.ridill.oar.core.ui.components.PasswordField
 import dev.ridill.oar.core.ui.components.SecureTextFieldKeyboardOptions
@@ -154,10 +152,9 @@ private fun PasswordUpdateSheet(
         }
     }
 
-    ModalBottomSheet(
+    OarModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
-        sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/dev/ridill/oar/transactions/presentation/addEditTransaction/AddEditTransactionScreen.kt
+++ b/app/src/main/java/dev/ridill/oar/transactions/presentation/addEditTransaction/AddEditTransactionScreen.kt
@@ -34,15 +34,12 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumFlexibleTopAppBar
 import androidx.compose.material3.MediumFloatingActionButton
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SelectableDates
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
@@ -88,6 +85,7 @@ import dev.ridill.oar.core.ui.components.ConfirmationDialog
 import dev.ridill.oar.core.ui.components.ExcludedIcon
 import dev.ridill.oar.core.ui.components.LabelledRadioButton
 import dev.ridill.oar.core.ui.components.OarDatePickerDialog
+import dev.ridill.oar.core.ui.components.OarModalBottomSheet
 import dev.ridill.oar.core.ui.components.OarPlainTooltip
 import dev.ridill.oar.core.ui.components.OarScaffold
 import dev.ridill.oar.core.ui.components.OarTextField
@@ -681,10 +679,9 @@ private fun RepetitionSelectionSheet(
     onRepetitionSelect: (ScheduleRepetition) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    ModalBottomSheet(
+    OarModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
-        sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
     ) {
         TitleLargeText(
             text = stringResource(R.string.select_schedule_repetition),


### PR DESCRIPTION
- Migrate `BackupEncryptionScreen` and `AddEditTransactionScreen` to use the custom `OarModalBottomSheet` component.
- Update `OarModalBottomSheet` default `sheetState` to restrict `enabledValues` to `Hidden` and `Expanded`, effectively disabling the half-expanded state.
- Refactor `AddEditFolderSheet` to use the Kotlin `Duration` API for the focus requester delay.