### PR TITLE
feat(datetime): Migrate date-time storage to UTC timestamps

### DIFF
--- a/app/schemas/dev.ridill.oar.core.data.db.OarDatabase/6.json
+++ b/app/schemas/dev.ridill.oar.core.data.db.OarDatabase/6.json
@@ -1,0 +1,441 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "04e5b9b45d21c57d7f8e1ce86a19f73a",
+    "entities": [
+      {
+        "tableName": "budget_cycle_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `start_date` TEXT NOT NULL, `end_date` TEXT NOT NULL, `budget` INTEGER NOT NULL, `currency_code` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budget",
+            "columnName": "budget",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_budget_cycle_table_start_date_end_date",
+            "unique": true,
+            "columnNames": [
+              "start_date",
+              "end_date"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_budget_cycle_table_start_date_end_date` ON `${TABLE_NAME}` (`start_date` DESC, `end_date` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "config_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`config_key` TEXT NOT NULL, `config_value` TEXT NOT NULL, PRIMARY KEY(`config_key`))",
+        "fields": [
+          {
+            "fieldPath": "configKey",
+            "columnName": "config_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configValue",
+            "columnName": "config_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "config_key"
+          ]
+        }
+      },
+      {
+        "tableName": "transaction_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `note` TEXT NOT NULL, `amount` REAL NOT NULL, `currency_code` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `type` TEXT NOT NULL, `is_excluded` INTEGER NOT NULL, `cycle_id` INTEGER NOT NULL, `tag_id` INTEGER, `folder_id` INTEGER, `schedule_id` INTEGER, FOREIGN KEY(`cycle_id`) REFERENCES `budget_cycle_table`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`tag_id`) REFERENCES `tag_table`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`folder_id`) REFERENCES `folder_table`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`schedule_id`) REFERENCES `schedules_table`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExcluded",
+            "columnName": "is_excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cycleId",
+            "columnName": "cycle_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "scheduleId",
+            "columnName": "schedule_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transaction_table_cycle_id",
+            "unique": false,
+            "columnNames": [
+              "cycle_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_table_cycle_id` ON `${TABLE_NAME}` (`cycle_id`)"
+          },
+          {
+            "name": "index_transaction_table_tag_id",
+            "unique": false,
+            "columnNames": [
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_table_tag_id` ON `${TABLE_NAME}` (`tag_id`)"
+          },
+          {
+            "name": "index_transaction_table_folder_id",
+            "unique": false,
+            "columnNames": [
+              "folder_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_table_folder_id` ON `${TABLE_NAME}` (`folder_id`)"
+          },
+          {
+            "name": "index_transaction_table_schedule_id",
+            "unique": false,
+            "columnNames": [
+              "schedule_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_table_schedule_id` ON `${TABLE_NAME}` (`schedule_id`)"
+          },
+          {
+            "name": "index_transaction_table_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transaction_table_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "budget_cycle_table",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cycle_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tag_table",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tag_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "folder_table",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "folder_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "schedules_table",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "schedule_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tag_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color_code` INTEGER NOT NULL, `created_timestamp` TEXT NOT NULL, `is_excluded` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorCode",
+            "columnName": "color_code",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdTimestamp",
+            "columnName": "created_timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExcluded",
+            "columnName": "is_excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "folder_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_timestamp` TEXT NOT NULL, `is_excluded` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdTimestamp",
+            "columnName": "created_timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExcluded",
+            "columnName": "is_excluded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "schedules_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `amount` REAL NOT NULL, `note` TEXT, `currency_code` TEXT NOT NULL, `type` TEXT NOT NULL, `tag_id` INTEGER, `folder_id` INTEGER, `repetition` TEXT NOT NULL, `last_payment_timestamp` TEXT, `next_payment_timestamp` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repetition",
+            "columnName": "repetition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPaymentTimestamp",
+            "columnName": "last_payment_timestamp",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nextPaymentTimestamp",
+            "columnName": "next_payment_timestamp",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "currency_list_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`currency_code` TEXT NOT NULL, `display_name` TEXT NOT NULL, PRIMARY KEY(`currency_code`))",
+        "fields": [
+          {
+            "fieldPath": "currencyCode",
+            "columnName": "currency_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "currency_code"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "transaction_details_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT tx.id AS transactionId,\n        tx.note AS transactionNote,\n        tx.amount AS transactionAmount,\n        tx.timestamp AS transactionTimestamp,\n        tx.type AS transactionType,\n        tx.currency_code AS currencyCode,\n        cyc.id AS cycleId,\n        cyc.start_date AS cycleStartDate,\n        cyc.end_date AS cycleEndDate,\n        tag.id AS tagId,\n        tag.name AS tagName,\n        tag.color_code AS tagColorCode,\n        tag.created_timestamp AS tagCreatedTimestamp,\n        folder.id AS folderId,\n        folder.name AS folderName,\n        folder.created_timestamp AS folderCreatedTimestamp,\n        tx.schedule_id as scheduleId,\n        (CASE WHEN 1 IN (tx.is_excluded, tag.is_excluded, folder.is_excluded) THEN 1 ELSE 0 END) AS excluded\n        FROM transaction_table tx\n        JOIN budget_cycle_table cyc ON tx.cycle_id = cyc.id\n        LEFT OUTER JOIN tag_table tag ON tx.tag_id = tag.id\n        LEFT OUTER JOIN folder_table folder ON tx.folder_id = folder.id"
+      },
+      {
+        "viewName": "budget_cycle_details_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT bdgt.id AS id,\n        bdgt.start_date AS startDate,\n        bdgt.end_date as endDate,\n        bdgt.budget AS budget,\n        bdgt.currency_code AS currencyCode,\n        IFNULL(SUM(\n                CASE\n                    WHEN tx.transactionType = 'DEBIT' THEN tx.transactionAmount\n                    WHEN tx.transactionType = 'CREDIT' THEN -tx.transactionAmount\n                END\n        ), 0) as aggregate,\n        CASE\n            WHEN cnfg.config_value IS NOT NULL THEN 1\n            ELSE 0\n        END AS active\n        FROM budget_cycle_table bdgt\n        LEFT OUTER JOIN config_table cnfg ON (cnfg.config_key = 'ACTIVE_CYCLE_ID' AND cnfg.config_value = bdgt.id)\n        LEFT OUTER JOIN transaction_details_view tx ON (tx.cycleId = bdgt.id AND tx.currencyCode = bdgt.currency_code AND tx.excluded = 0)\n        GROUP BY bdgt.id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '04e5b9b45d21c57d7f8e1ce86a19f73a')"
+    ]
+  }
+}

--- a/app/src/main/java/dev/ridill/oar/core/data/db/DateTimeConverter.kt
+++ b/app/src/main/java/dev/ridill/oar/core/data/db/DateTimeConverter.kt
@@ -1,28 +1,27 @@
 package dev.ridill.oar.core.data.db
 
 import androidx.room.TypeConverter
-import dev.ridill.oar.core.domain.util.DateUtil
 import dev.ridill.oar.core.domain.util.tryOrNull
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.time.ZoneId
 
 class DateTimeConverter {
 
     @TypeConverter
     fun fromDateTimeString(value: String?): LocalDateTime? = tryOrNull {
         value?.let {
-            DateUtil.parseDateTime(
-                it, DateUtil.Formatters
-                    .formatterWithDefault(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-            )
-            LocalDateTime.parse(it)
+            // Try parsing as a UTC instant first (new format: "2026-06-30T05:00:00Z"),
+            // then fall back to plain local datetime for existing records ("2026-06-30T10:30:00").
+            tryOrNull { Instant.parse(it).atZone(ZoneId.systemDefault()).toLocalDateTime() }
+                ?: LocalDateTime.parse(it)
         }
     }
 
     @TypeConverter
     fun toDateTimeString(dateTime: LocalDateTime?): String? = tryOrNull {
-        dateTime?.toString()
+        dateTime?.atZone(ZoneId.systemDefault())?.toInstant()?.toString()
     }
 
     @TypeConverter

--- a/app/src/main/java/dev/ridill/oar/core/data/db/OarDatabase.kt
+++ b/app/src/main/java/dev/ridill/oar/core/data/db/OarDatabase.kt
@@ -4,6 +4,8 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import dev.ridill.oar.aggregations.data.local.AggregationsDao
 import dev.ridill.oar.budgetCycles.data.local.BudgetCycleDao
 import dev.ridill.oar.budgetCycles.data.local.entity.BudgetCycleEntity
@@ -21,6 +23,8 @@ import dev.ridill.oar.tags.data.local.entity.TagEntity
 import dev.ridill.oar.transactions.data.local.TransactionDao
 import dev.ridill.oar.transactions.data.local.entity.TransactionEntity
 import dev.ridill.oar.transactions.data.local.views.TransactionDetailsView
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Database(
     entities = [
@@ -36,7 +40,7 @@ import dev.ridill.oar.transactions.data.local.views.TransactionDetailsView
         BudgetCycleDetailsView::class,
         TransactionDetailsView::class,
     ],
-    version = 5,
+    version = 6,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -62,4 +66,49 @@ abstract class OarDatabase : RoomDatabase() {
     abstract fun schedulesDao(): SchedulesDao
     abstract fun currencyListDao(): CurrencyListDao
     abstract fun configDao(): ConfigDao
+}
+
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        val zone = ZoneId.systemDefault()
+        migrateColumn(db, zone, "transaction_table", "id", "timestamp")
+        migrateColumn(db, zone, "schedules_table", "id", "last_payment_timestamp")
+        migrateColumn(db, zone, "schedules_table", "id", "next_payment_timestamp")
+        migrateColumn(db, zone, "folder_table", "id", "created_timestamp")
+        migrateColumn(db, zone, "tag_table", "id", "created_timestamp")
+    }
+
+    private fun migrateColumn(
+        db: SupportSQLiteDatabase,
+        zone: ZoneId,
+        table: String,
+        idColumn: String,
+        column: String
+    ) {
+        val cursor = db.query(
+            "SELECT $idColumn, $column FROM $table WHERE $column IS NOT NULL"
+        )
+        try {
+            while (cursor.moveToNext()) {
+                val id = cursor.getLong(0)
+                val value = cursor.getString(1) ?: continue
+                // Skip rows that are already in UTC instant format
+                if (value.endsWith('Z') || value.contains('+')) continue
+                val utcStr = runCatching {
+                    LocalDateTime.parse(value)
+                        .atZone(zone)
+                        .toInstant()
+                        .toString()
+                }.getOrNull() ?: continue
+                db.execSQL(
+                    "UPDATE $table SET $column = ? WHERE $idColumn = ?",
+                    arrayOf<Any>(utcStr, id)
+                )
+            }
+        } catch (_: Throwable) {
+
+        } finally {
+            cursor.close()
+        }
+    }
 }

--- a/app/src/main/java/dev/ridill/oar/core/data/preferences/PreferencesManagerImpl.kt
+++ b/app/src/main/java/dev/ridill/oar/core/data/preferences/PreferencesManagerImpl.kt
@@ -12,6 +12,8 @@ import dev.ridill.oar.core.domain.util.logE
 import dev.ridill.oar.core.domain.util.orFalse
 import dev.ridill.oar.core.domain.util.orTrue
 import dev.ridill.oar.core.domain.util.tryOrNull
+import java.time.Instant
+import java.time.ZoneId
 import dev.ridill.oar.settings.domain.appLock.AppAutoLockInterval
 import dev.ridill.oar.settings.domain.modal.AppTheme
 import dev.ridill.oar.settings.domain.repositoty.FatalBackupError
@@ -41,7 +43,10 @@ class PreferencesManagerImpl(
             )
             val dynamicColorsEnabled = preferences[Keys.DYNAMIC_COLORS_ENABLED].orFalse()
             val lastBackupDateTime = preferences[Keys.LAST_BACKUP_TIMESTAMP]
-                ?.let { DateUtil.parseDateTimeOrNull(it) }
+                ?.let { str ->
+                    tryOrNull { Instant.parse(str).atZone(ZoneId.systemDefault()).toLocalDateTime() }
+                        ?: DateUtil.parseDateTimeOrNull(str)
+                }
             val transactionAutoDetectEnabled =
                 preferences[Keys.TRANSACTION_AUTO_DETECT_ENABLED].orFalse()
             val allTransactionsShowExcludedOption =
@@ -100,7 +105,10 @@ class PreferencesManagerImpl(
     override suspend fun updateLastBackupTimestamp(localDateTime: LocalDateTime) {
         withContext(Dispatchers.IO) {
             dataStore.edit { preferences ->
-                preferences[Keys.LAST_BACKUP_TIMESTAMP] = localDateTime.toString()
+                preferences[Keys.LAST_BACKUP_TIMESTAMP] = localDateTime
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toString()
             }
         }
     }

--- a/app/src/main/java/dev/ridill/oar/di/AppModule.kt
+++ b/app/src/main/java/dev/ridill/oar/di/AppModule.kt
@@ -17,6 +17,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.ridill.oar.application.OarViewModel
+import dev.ridill.oar.core.data.db.MIGRATION_5_6
 import dev.ridill.oar.core.data.db.OarDatabase
 import dev.ridill.oar.core.data.preferences.PreferencesManager
 import dev.ridill.oar.core.data.preferences.PreferencesManagerImpl
@@ -52,6 +53,7 @@ object AppModule {
             klass = OarDatabase::class.java,
             name = OarDatabase.NAME
         )
+        .addMigrations(MIGRATION_5_6)
         .fallbackToDestructiveMigration(dropAllTables = false)
         .build()
 

--- a/app/src/main/java/dev/ridill/oar/transactions/presentation/addEditTransaction/AddEditTransactionState.kt
+++ b/app/src/main/java/dev/ridill/oar/transactions/presentation/addEditTransaction/AddEditTransactionState.kt
@@ -31,5 +31,5 @@ data class AddEditTransactionState(
     val selectedCycleId: Long? = null,
 ) {
     val timestampUtc: ZonedDateTime
-        get() = timestamp.atZone(ZoneId.of(ZoneOffset.UTC.id))
+        get() = timestamp.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC)
 }

--- a/app/src/main/java/dev/ridill/oar/transactions/presentation/addEditTransaction/AddEditTransactionViewModel.kt
+++ b/app/src/main/java/dev/ridill/oar/transactions/presentation/addEditTransaction/AddEditTransactionViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.ZoneOffset
 import java.util.Currency
 import javax.inject.Inject
 
@@ -320,7 +321,8 @@ class AddEditTransactionViewModel @Inject constructor(
         savedStateHandle[TX_INPUT] = txInput.value?.copy(
             timestamp = DateUtil.dateFromMillisWithTime(
                 millis = millis,
-                time = txInput.value?.timestamp?.toLocalTime() ?: DateUtil.timeNow()
+                time = txInput.value?.timestamp?.toLocalTime() ?: DateUtil.timeNow(),
+                zoneId = ZoneOffset.UTC
             )
         )
         savedStateHandle[SHOW_DATE_PICKER] = false


### PR DESCRIPTION
- Increment database version to 6 and implement `MIGRATION_5_6` to convert existing local date-time strings to UTC ISO strings across the transactions, schedules, folders, and tags tables.
- Update Room `DateTimeConverter` to store `LocalDateTime` as UTC `Instant` strings while maintaining backward compatibility for parsing legacy local formats.
- Refactor `PreferencesManager` to save and retrieve the last backup timestamp using UTC instants, including fallback parsing for existing local timestamps.
- Adjust `AddEditTransactionState` and `AddEditTransactionViewModel` to ensure transaction timestamps are correctly derived from the system's default time zone and converted to UTC.
- Register `MIGRATION_5_6` in the `AppModule` database provider.